### PR TITLE
Oppdater hjelpetekst etter publisering av 2. kvartal

### DIFF
--- a/client/src/Pages/Prioritering/PrioriteringsTabell.tsx
+++ b/client/src/Pages/Prioritering/PrioriteringsTabell.tsx
@@ -130,7 +130,7 @@ const PrioriteringsTabell = ({
                     <Detail size={"small"} style={{alignSelf: "center"}}>
                         Viser {(side - 1) * ANTALL_RESULTATER_PER_SIDE + 1}-{Math.min(side * ANTALL_RESULTATER_PER_SIDE, totaltAntallResultaterISøk)} av
                         totalt {totaltAntallResultaterISøk} søkeresultater.
-                        Tallene viser offisiell sykefraværsstatistikk for første kvartal 2022.
+                        Tallene viser offisiell sykefraværsstatistikk for andre kvartal 2022.
                     </Detail>
                 </div>
             }


### PR DESCRIPTION
OBS: ikke merge før import er ferdig.
"Manuel" oppdatering av hjelpetekst for å matche siste publisering av statistikk 