### PR TITLE
Csp directives for amplitude

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,7 +75,7 @@ jobs:
         cluster: [dev]
     name: Deploy app to ${{ matrix.cluster }}
     needs: build
-    if: github.ref == 'refs/heads/csrf_rewrite'
+    if: github.ref == 'refs/heads/csp-directives-for-amplitude'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/client/__tests__/amplitude-klient-utils.test.ts
+++ b/client/__tests__/amplitude-klient-utils.test.ts
@@ -1,6 +1,6 @@
 import { maskerOrgnr } from "../src/util/amplitude-klient-utils";
 
-describe("Masker orgn (9 siffer) i url", () => {
+describe("Masker orgnr (9 siffer) i url", () => {
     test("URL blir uendreet dersom det ikke er noe å maskere", () => {
         expect(maskerOrgnr(undefined)).toBe('');
         expect(maskerOrgnr('')).toBe('');

--- a/client/__tests__/amplitude-klient-utils.test.ts
+++ b/client/__tests__/amplitude-klient-utils.test.ts
@@ -1,7 +1,7 @@
 import { maskerOrgnr } from "../src/util/amplitude-klient-utils";
 
 describe("Masker orgnr (9 siffer) i url", () => {
-    test("URL blir uendreet dersom det ikke er noe å maskere", () => {
+    test("URL blir uendret dersom det ikke er noe å maskere", () => {
         expect(maskerOrgnr(undefined)).toBe('');
         expect(maskerOrgnr('')).toBe('');
         expect(maskerOrgnr('ingen url her')).toBe('ingen url her');

--- a/client/__tests__/amplitude-klient-utils.test.ts
+++ b/client/__tests__/amplitude-klient-utils.test.ts
@@ -1,0 +1,15 @@
+import { maskerOrgnr } from "../src/util/amplitude-klient-utils";
+
+describe("Masker orgn (9 siffer) i url", () => {
+    test("URL blir uendreet dersom det ikke er noe å maskere", () => {
+        expect(maskerOrgnr(undefined)).toBe('');
+        expect(maskerOrgnr('')).toBe('');
+        expect(maskerOrgnr('ingen url her')).toBe('ingen url her');
+        expect(maskerOrgnr('http://localhost:2222/statusoversikt')).toBe('http://localhost:2222/statusoversikt');
+    });
+
+    test("Masker orgnr i url", () => {
+        expect(maskerOrgnr('http://localhost:2222/virksomhet/852409131')).toBe('http://localhost:2222/virksomhet/*********');
+    });
+
+});

--- a/client/src/Pages/Statusoversikt/Statusoversiktside.tsx
+++ b/client/src/Pages/Statusoversikt/Statusoversiktside.tsx
@@ -7,6 +7,7 @@ import { Statusoversikt } from "../../domenetyper/statusoversikt";
 import { statiskeSidetitler, useTittel } from "../../util/useTittel";
 import { StatistikkTabell } from "./StatistikkTabell";
 import { SideContainer } from "../../styling/containere";
+import { loggSideLastet } from "../../util/amplitude-klient";
 
 export const Statusoversiktside = () => {
     useTittel(statiskeSidetitler.statusoversiktside)
@@ -38,6 +39,7 @@ export const Statusoversiktside = () => {
         if (filterverdier && !filtervisningLoaded) {
             filtervisning.lastData({ filterverdier });
             setFiltervisningLoaded(true);
+            loggSideLastet("Statusoversiktside");
         }
     });
 

--- a/client/src/Pages/Virksomhet/Virksomhetsside.tsx
+++ b/client/src/Pages/Virksomhet/Virksomhetsside.tsx
@@ -4,6 +4,7 @@ import { Loader } from "@navikt/ds-react";
 import { useHentVirksomhetsinformasjon } from "../../api/lydia-api";
 import { VirksomhetsVisning } from "./VirksomhetsVisning";
 import { statiskeSidetitler, useTittel } from "../../util/useTittel";
+import { loggSideLastet } from "../../util/amplitude-klient";
 
 export const Virksomhetsside = () => {
     const { oppdaterTittel } = useTittel(statiskeSidetitler.virksomhetsside)
@@ -15,8 +16,10 @@ export const Virksomhetsside = () => {
     } = useHentVirksomhetsinformasjon(orgnummer);
 
     useEffect(() => {
-        if (virksomhetsinformasjon)
-            oppdaterTittel(`Fia - ${virksomhetsinformasjon.navn}`)
+        if (virksomhetsinformasjon) {
+            oppdaterTittel(`Fia - ${virksomhetsinformasjon.navn}`);
+            loggSideLastet("Virksomhetsside");
+        }
     }, [virksomhetsinformasjon?.navn])
 
     if (lasterVirksomhet) {

--- a/client/src/util/amplitude-klient-utils.ts
+++ b/client/src/util/amplitude-klient-utils.ts
@@ -1,0 +1,11 @@
+
+export const maskerOrgnr = (url: string | undefined): string => {
+    if (url) {
+        const regex = /\d{9}/g;
+        return url.length > 8 ?
+            url.replace(regex, '*********')
+            : url;
+    } else {
+        return '';
+    }
+}

--- a/client/src/util/amplitude-klient.ts
+++ b/client/src/util/amplitude-klient.ts
@@ -1,4 +1,5 @@
 import amplitude, { AmplitudeClient } from "amplitude-js";
+import { maskerOrgnr } from "./amplitude-klient-utils";
 
 const amplitudeKlient : AmplitudeClient = amplitude.getInstance();
 
@@ -8,11 +9,31 @@ const apiKeys = {
     fiaProd: "747d79b00c945cf3e549ae0b197293bf",
     fiaDev: "747f1d150abf4cad4248ff1d3f93e999"
 };
+
 const isProduction = () =>
     typeof window !== "undefined" &&
     window.location.hostname === "fia.intern.nav.no";
 
-export const loggSideLastet = (side: string) => {
+/**
+ *  Gyldige events: https://github.com/navikt/analytics-taxonomy/tree/main/events
+ */
+type validEventNames =
+    | 'besøk'
+    | 'navigere'
+    | 'alert vist'
+    | 'accordion åpnet'
+    | 'accordion lukket'
+    | 'knapp klikket'
+    | 'modal åpnet'
+    | 'modal lukket'
+
+export const loggSideLastet = (sidetittel: string) => {
+    const url = window? window.location.href : '';
+    const maskertUrl = maskerOrgnr(url);
+    logAmplitudeEvent('besøk', {url: maskertUrl, sidetittel: sidetittel})
+};
+
+const logAmplitudeEvent = (eventName: validEventNames, eventData: Record<string, string | boolean>) => {
     if (!initialized) {
         const apiKey = isProduction()
             ? apiKeys.fiaProd
@@ -23,5 +44,5 @@ export const loggSideLastet = (side: string) => {
         });
         initialized = true;
     }
-    amplitudeKlient.logEvent("side-lastet",{side : side} );
+    amplitudeKlient.logEvent(eventName, eventData);
 };

--- a/client/src/util/amplitude-klient.ts
+++ b/client/src/util/amplitude-klient.ts
@@ -10,7 +10,7 @@ const apiKeys = {
 };
 export const loggSideLastet = (side: string) => {
     if (!initialized) {
-        const apiKey = process.env.NODE_ENV === "production"
+        const apiKey = process.env.NAIS_CLUSTER_NAME === "prod-gcp"
             ? apiKeys.fiaProd
             : apiKeys.fiaDev;
 

--- a/client/src/util/amplitude-klient.ts
+++ b/client/src/util/amplitude-klient.ts
@@ -8,9 +8,13 @@ const apiKeys = {
     fiaProd: "747d79b00c945cf3e549ae0b197293bf",
     fiaDev: "747f1d150abf4cad4248ff1d3f93e999"
 };
+const isProduction = () =>
+    typeof window !== "undefined" &&
+    window.location.hostname === "fia.intern.nav.no";
+
 export const loggSideLastet = (side: string) => {
     if (!initialized) {
-        const apiKey = process.env.NAIS_CLUSTER_NAME === "prod-gcp"
+        const apiKey = isProduction()
             ? apiKeys.fiaProd
             : apiKeys.fiaDev;
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -39,7 +39,7 @@ export default class Application {
                         scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
                         connectSrc: ["'self'", "*.nav.no"],
                         styleSrc: ["'self'", "'unsafe-inline'"],
-                        imgSrc: ["'self'"],
+                        imgSrc: ["'self'", "data:", "*.nav.no"],
                     },
                 }
             }));

--- a/server/app.ts
+++ b/server/app.ts
@@ -32,7 +32,17 @@ export default class Application {
         this.expressApp.set("trust proxy", 1);
 
         this.expressApp.use(apiMetrics());
-        this.expressApp.use(helmet());
+            this.expressApp.use(helmet({
+                contentSecurityPolicy: {
+                    directives: {
+                        defaultSrc: ["'self'"],
+                        scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+                        connectSrc: ["'self'", "*.nav.no"],
+                        styleSrc: ["'self'", "'unsafe-inline'"],
+                        imgSrc: ["'self'"],
+                    },
+                }
+            }));
 
         this.expressApp.all("*", (req, res, next) => {
             res.locals.requestId = randomUUID()


### PR DESCRIPTION
Denne PR inneholder endringer som skal til for å kunne sende eventer til Amplitude fra interne flater:
 - sette opp en amplitude-klient med public-keys til Fia prosjektet i Amplitude (dev og prod)
 - CSP directives for å kunne kjøre direkte kall fra app til amplitude.nav.no (Amplitude proxy)
 - enforce bruk av NAVs taxonomi for Amplitude events