### PR TITLE
Flytte metrics til internal

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,7 @@ jobs:
     permissions: {}
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/rename-fra-sykefraver'
+    if: github.ref == 'refs/heads/flytte-metrics-til-internal'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -25,7 +25,7 @@ spec:
       cpu: 100m
   prometheus:
     enabled: true
-    path: "/metrics"
+    path: "/internal/metrics"
   accessPolicy:
     outbound:
       rules:

--- a/server/__tests__/app.test.ts
+++ b/server/__tests__/app.test.ts
@@ -166,7 +166,7 @@ describe("Tester uthenting av metrikker", () => {
         const superTest = request(expressApp);
         const livenessCheck = await superTest.get("/internal/isAlive")
         expect(livenessCheck.statusCode).toBe(200)
-        const metricsCollection = await superTest.get("/metrics")
+        const metricsCollection = await superTest.get("/internal/metrics")
         expect(metricsCollection.text).toContain("process_cpu_user_seconds_total")
         expect(metricsCollection.text).toContain("http_request_size_bytes_bucket")
         expect(metricsCollection.text).toContain("http_response_size_bytes_bucket")

--- a/server/app.ts
+++ b/server/app.ts
@@ -31,18 +31,20 @@ export default class Application {
         this.expressApp = express();
         this.expressApp.set("trust proxy", 1);
 
-        this.expressApp.use(apiMetrics());
-            this.expressApp.use(helmet({
-                contentSecurityPolicy: {
-                    directives: {
-                        defaultSrc: ["'self'"],
-                        scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-                        connectSrc: ["'self'", "*.nav.no"],
-                        styleSrc: ["'self'", "'unsafe-inline'"],
-                        imgSrc: ["'self'", "data:", "*.nav.no"],
-                    },
-                }
-            }));
+        this.expressApp.use(apiMetrics(
+            {metricsPath: "/internal/metrics"}
+        ));
+        this.expressApp.use(helmet({
+            contentSecurityPolicy: {
+                directives: {
+                    defaultSrc: ["'self'"],
+                    scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+                    connectSrc: ["'self'", "*.nav.no"],
+                    styleSrc: ["'self'", "'unsafe-inline'"],
+                    imgSrc: ["'self'", "data:", "*.nav.no"],
+                },
+            }
+        }));
 
         this.expressApp.all("*", (req, res, next) => {
             res.locals.requestId = randomUUID()


### PR DESCRIPTION
Metrics er nå tilgjengelig (internt) på `/internal/metrics` 
Fungerer i test (sjekket i Grafana)