### PR TITLE
Fiks digestabot-versjon i chainguard-workflow

### DIFF
--- a/.github/workflows/check-image-update.yml
+++ b/.github/workflows/check-image-update.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6 # Immutable release
         with:
           persist-credentials: false
-      - uses: navikt/digestabot@v1 # Immutable release
+      - uses: navikt/digestabot@v1.1.1 # Immutable release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           team: pia


### PR DESCRIPTION
Oppdaterer digestabot fra @v1 (som ikke finnes) til @v1.1.1.