### PR TITLE
Sikkerhetstiltak for å unngå bruk (nedlasting) av alt for nylig publiserte pakker 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ registries:
 updates:
   - package-ecosystem: github-actions
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: "monday"
@@ -19,6 +21,8 @@ updates:
 
   - package-ecosystem: npm
     directory: "/client"
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: "monday"
@@ -68,13 +72,13 @@ updates:
         patterns:
           - "highcharts"
           - "highcharts-react-official"
-    cooldown:
-      default-days: 7
     registries:
       - npm-github
 
   - package-ecosystem: npm
     directory: "/server"
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: "monday"
@@ -106,8 +110,6 @@ updates:
           - "express-session"
           - "@types/express"
           - "@types/express-session"
-    cooldown:
-      default-days: 7
 
   - package-ecosystem: docker
     directory: "/client"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/ikke-patche-dev'
+    if: github.ref == 'refs/heads/bruk-av-minreleaseage-i-pnpm-conf'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -2,7 +2,10 @@ allowBuilds:
   esbuild: true
   '@parcel/watcher': true
   unrs-resolver: true
-# Sett minimumReleaseAge for å unngå at pakker som nylig er publisert blir brukt i byggene.
+
+# Sett minimumReleaseAge for å unngå at pakker som nylig er publisert (< 7 dager) blir brukt i byggene.
+# Sikkerhetstiltak for å unngå at vi bruker pakker som nylig er publisert og som potensielt kan være ondsinnede eller ustabile.
 minimumReleaseAge: 10080 # 7 dager
+
 minimumReleaseAgeExclude:
   - "@navikt/*"

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ allowBuilds:
   esbuild: true
   '@parcel/watcher': true
   unrs-resolver: true
+# Sett minimumReleaseAge for å unngå at pakker som nylig er publisert blir brukt i byggene.
+minimumReleaseAge: 10080 # 7 dager
+minimumReleaseAgeExclude:
+  - "@navikt/*"

--- a/server/pnpm-workspace.yaml
+++ b/server/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 allowBuilds:
   unrs-resolver: true
+# Sett minimumReleaseAge for å unngå at pakker som nylig er publisert blir brukt i byggene.
+minimumReleaseAge: 10080 # 7 dager
+minimumReleaseAgeExclude:
+  - "@navikt/*"

--- a/server/pnpm-workspace.yaml
+++ b/server/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 allowBuilds:
   unrs-resolver: true
-# Sett minimumReleaseAge for å unngå at pakker som nylig er publisert blir brukt i byggene.
+
+# Sett minimumReleaseAge for å unngå at pakker som nylig er publisert (< 7 dager) blir brukt i byggene.
+# Sikkerhetstiltak for å unngå at vi bruker pakker som nylig er publisert og som potensielt kan være ondsinnede eller ustabile.
 minimumReleaseAge: 10080 # 7 dager
+
 minimumReleaseAgeExclude:
   - "@navikt/*"


### PR DESCRIPTION
To endringer i denne PR: 
 - Legge til `minimumReleaseAge` i pnpm project config og sette den til 7 dager
 - Sette `cooldown` til 7 dager for GH actions i dependabot 
