### PR TITLE
Legg til tilstand for virksomhet fjernet/slettet

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/ta-i-bruk-endepunkter-paa-nyflyt-api-path'
+    if: github.ref == 'refs/heads/virksomhet-tilstand-slettet'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dette vert orkestrert av docker-compose.
 
 ### Tilgang til npm pakker på github
 
-Lag token på github med packages:read rettigheter.
+Lag token på github med packages:read rettigheter. Autoriser token for navikt (klikk dropdown `Configure SSO`, velg navikt).
 Legg så dette inn i ~/.npmrc slik som dette:
 `//npm.pkg.github.com/:_authToken=<generert token med packages:read rettigheter>`
 

--- a/client/src/Pages/Virksomhet/Sakshistorikk/SakshistorikkTabell.tsx
+++ b/client/src/Pages/Virksomhet/Sakshistorikk/SakshistorikkTabell.tsx
@@ -107,6 +107,13 @@ export const SakshistorikkTabell = ({
                                             "SLETT_PROSESS" && (
                                             <Detail>Slettet samarbeid</Detail>
                                         )}
+                                        {sakSnapshot.hendelsestype ===
+                                            "VIRKSOMHET_AVREGISTRERT" && (
+                                            <Detail>
+                                                Virksomheten ble slettet i
+                                                Brønnøysundregistrene
+                                            </Detail>
+                                        )}
                                         {sakSnapshot.status === "NY" && (
                                             <Detail>Opprettet sak</Detail>
                                         )}

--- a/client/src/Pages/Virksomhet/Virksomhetsheader/Topplinje/Topplinje.test.tsx
+++ b/client/src/Pages/Virksomhet/Virksomhetsheader/Topplinje/Topplinje.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Topplinje } from "./index";
+import { Virksomhet } from "../../../../domenetyper/virksomhet";
+
+jest.mock("../../../../api/lydia-api/nyFlyt", () => ({
+    useHentTilstandForVirksomhetNyFlyt: jest.fn(),
+}));
+
+jest.mock("../../../../api/lydia-api/virksomhet", () => ({
+    useHentSalesforceUrl: jest.fn(),
+}));
+
+import { useHentTilstandForVirksomhetNyFlyt } from "../../../../api/lydia-api/nyFlyt";
+import { useHentSalesforceUrl } from "../../../../api/lydia-api/virksomhet";
+
+const virksomhet: Virksomhet = {
+    orgnr: "123456789",
+    navn: "Test AS",
+    adresse: ["Testgaten 1"],
+    postnummer: "0001",
+    poststed: "OSLO",
+    næring: { navn: "Somatiske sykehus", kode: "86.101" },
+    næringsundergruppe1: { navn: "Sykehustjenester", kode: "86.1" },
+    næringsundergruppe2: null,
+    næringsundergruppe3: null,
+    bransje: null,
+    status: "FJERNET",
+    aktivtSaksnummer: null,
+};
+
+describe("Topplinje — VirksomhetErAvregistrertIBrreg", () => {
+    beforeEach(() => {
+        (useHentTilstandForVirksomhetNyFlyt as jest.Mock).mockReturnValue({
+            data: {
+                orgnr: virksomhet.orgnr,
+                tilstand: "VirksomhetErAvregistrertIBrreg",
+                nesteTilstand: null,
+            },
+            loading: false,
+        });
+        (useHentSalesforceUrl as jest.Mock).mockReturnValue({
+            data: { url: "https://salesforce.example.com/123456789" },
+        });
+    });
+
+    it("viser Salesforce-lenke", () => {
+        render(<Topplinje virksomhet={virksomhet} />);
+        expect(
+            screen.getByText("Salesforce - virksomhet"),
+        ).toBeInTheDocument();
+    });
+
+    it("viser ingen handlingsknapper", () => {
+        render(<Topplinje virksomhet={virksomhet} />);
+        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+});

--- a/client/src/Pages/Virksomhet/Virksomhetsheader/Topplinje/VirksomhetErAvregistrertIBrreg.tsx
+++ b/client/src/Pages/Virksomhet/Virksomhetsheader/Topplinje/VirksomhetErAvregistrertIBrreg.tsx
@@ -1,0 +1,10 @@
+import { Virksomhet } from "../../../../domenetyper/virksomhet";
+import { Salesforcelenke } from "..";
+
+export default function VirksomhetErAvregistrertIBrreg({
+    virksomhet,
+}: {
+    virksomhet: Virksomhet;
+}) {
+    return <Salesforcelenke orgnr={virksomhet.orgnr} />;
+}

--- a/client/src/Pages/Virksomhet/Virksomhetsheader/Topplinje/index.tsx
+++ b/client/src/Pages/Virksomhet/Virksomhetsheader/Topplinje/index.tsx
@@ -13,6 +13,8 @@ import VirksomhetErVurdert from "./VirksomhetErVurdert";
 import VirksomhetHarAktiveSamarbeid from "./VirksomhetHarAktiveSamarbeid";
 import AlleSamarbeidIVirksomhetErAvsluttet from "./AlleSamarbeidIVirksomhetErAvsluttet";
 import VirksomhetKlarTilVurdering from "./VirksomhetKlarTilVurdering";
+import { exhaustive } from "../../../../util/exhaustive_types";
+import VirksomhetErAvregistrertIBrreg from "./VirksomhetErAvregistrertIBrreg";
 
 export function Topplinje({
     virksomhet,
@@ -37,61 +39,49 @@ export function Topplinje({
         );
     }
 
-    if (
-        tilstand?.tilstand ===
-        VirksomhetIATilstandEnum.enum.VirksomhetKlarTilVurdering
-    ) {
-        return <VirksomhetKlarTilVurdering virksomhet={virksomhet} />;
-    }
-
-    if (
-        tilstand?.tilstand === VirksomhetIATilstandEnum.enum.VirksomhetVurderes
-    ) {
-        return <VirksomhetVurderes iaSak={iaSak!} virksomhet={virksomhet} />;
-    }
-
-    if (
-        tilstand?.tilstand === VirksomhetIATilstandEnum.enum.VirksomhetErVurdert
-    ) {
-        return (
-            <VirksomhetErVurdert
-                iaSak={iaSak!}
-                tilstand={tilstand}
-                virksomhet={virksomhet}
-            />
-        );
-    }
-
-    if (
-        tilstand?.tilstand ===
-        VirksomhetIATilstandEnum.enum.VirksomhetHarAktiveSamarbeid
-    ) {
-        return (
-            <VirksomhetHarAktiveSamarbeid
-                iaSak={iaSak!}
-                virksomhet={virksomhet}
-            />
-        );
-    }
-
-    if (
-        tilstand?.tilstand ===
-        VirksomhetIATilstandEnum.enum.AlleSamarbeidIVirksomhetErAvsluttet
-    ) {
-        return (
-            <AlleSamarbeidIVirksomhetErAvsluttet
-                iaSak={iaSak!}
-                virksomhet={virksomhet}
-                tilstand={tilstand}
-            />
-        );
+    switch (tilstand?.tilstand) {
+        case VirksomhetIATilstandEnum.enum.VirksomhetKlarTilVurdering:
+            return <VirksomhetKlarTilVurdering virksomhet={virksomhet} />;
+        case VirksomhetIATilstandEnum.enum.VirksomhetVurderes:
+            return (
+                <VirksomhetVurderes iaSak={iaSak!} virksomhet={virksomhet} />
+            );
+        case VirksomhetIATilstandEnum.enum.VirksomhetErVurdert:
+            return (
+                <VirksomhetErVurdert
+                    iaSak={iaSak!}
+                    tilstand={tilstand}
+                    virksomhet={virksomhet}
+                />
+            );
+        case VirksomhetIATilstandEnum.enum.VirksomhetHarAktiveSamarbeid:
+            return (
+                <VirksomhetHarAktiveSamarbeid
+                    iaSak={iaSak!}
+                    virksomhet={virksomhet}
+                />
+            );
+        case VirksomhetIATilstandEnum.enum.AlleSamarbeidIVirksomhetErAvsluttet:
+            return (
+                <AlleSamarbeidIVirksomhetErAvsluttet
+                    iaSak={iaSak!}
+                    virksomhet={virksomhet}
+                    tilstand={tilstand}
+                />
+            );
+        case VirksomhetIATilstandEnum.enum.VirksomhetErAvregistrertIBrreg:
+            return <VirksomhetErAvregistrertIBrreg virksomhet={virksomhet} />;
+        case undefined:
+            break;
+        default:
+            if (tilstand) exhaustive(tilstand?.tilstand);
     }
 
     console.log("ikke implementert", {
         virksomhet,
         iaSak,
         samarbeid,
-        tilstand,
+        tilstand: tilstand,
     });
 
     return "Ikke implementert";

--- a/client/src/components/Badge/StatusBadge.tsx
+++ b/client/src/components/Badge/StatusBadge.tsx
@@ -1,6 +1,7 @@
 import "@navikt/ds-css";
-import { Tag, TagProps } from "@navikt/ds-react";
+import { Tag, TagProps, Tooltip } from "@navikt/ds-react";
 import styles from "./badge.module.scss";
+import { useMemo } from "react";
 
 export interface GenericProps<T> extends Omit<
     TagProps,
@@ -9,6 +10,7 @@ export interface GenericProps<T> extends Omit<
     status: T;
     penskrivStatus: (status: T) => string;
     hentTagProps?: (status: T) => Omit<TagProps, "variant" | "children">;
+    hentHjelpetekst?: (status: T) => string | undefined;
     as?: React.ElementType;
 }
 
@@ -17,22 +19,31 @@ export function GenericStatusBadge<T>({
     penskrivStatus,
     hentTagProps = () => ({}),
     className,
+    hentHjelpetekst = () => undefined,
     as = "div",
     ...remainingProps
 }: GenericProps<T>) {
     const Component = as;
+    const hjelpetekst = useMemo(() => hentHjelpetekst(status), [status]);
+
+    const tag = (
+        <Tag
+            {...remainingProps}
+            className={`${styles.statusTag} ${styles.slim} `}
+            {...hentTagProps(status)}
+            size="small"
+        >
+            {penskrivStatus(status)}
+        </Tag>
+    );
+
     return (
         <Component
             className={`${styles.statusBadge} ${className ? className : ""}`}
         >
-            <Tag
-                {...remainingProps}
-                className={`${styles.statusTag} ${styles.slim} `}
-                {...hentTagProps(status)}
-                size="small"
-            >
-                {penskrivStatus(status)}
-            </Tag>
+            {hjelpetekst
+                ? <Tooltip content={hjelpetekst} describesChild>{tag}</Tooltip>
+                : tag}
         </Component>
     );
 }

--- a/client/src/components/Badge/VirksomhetTilstandStatusBadge.tsx
+++ b/client/src/components/Badge/VirksomhetTilstandStatusBadge.tsx
@@ -41,6 +41,8 @@ export function penskrivVirksomhetTilstand(tilstand: VirksomhetIATilstand) {
             return "Aktiv";
         case VirksomhetIATilstandEnum.enum.AlleSamarbeidIVirksomhetErAvsluttet:
             return "Avsluttet";
+        case VirksomhetIATilstandEnum.enum.VirksomhetErAvregistrertIBrreg:
+            return "Slettet";
         default:
             exhaustive(tilstand);
             return tilstand;
@@ -58,6 +60,9 @@ function hentTagPropsForVirksomhetTilstand(
         case VirksomhetIATilstandEnum.enum.VirksomhetHarAktiveSamarbeid:
             return { variant: "outline", "data-color": "brand-blue" };
         case VirksomhetIATilstandEnum.enum.AlleSamarbeidIVirksomhetErAvsluttet:
+            return { variant: "strong", "data-color": "neutral" };
+        case VirksomhetIATilstandEnum.enum.VirksomhetErAvregistrertIBrreg:
+            return { variant: "outline", "data-color": "brand-magenta" };
         case VirksomhetIATilstandEnum.enum.VirksomhetKlarTilVurdering:
             break;
         default:

--- a/client/src/components/Badge/VirksomhetTilstandStatusBadge.tsx
+++ b/client/src/components/Badge/VirksomhetTilstandStatusBadge.tsx
@@ -24,6 +24,7 @@ export function VirksomhetTilstandStatusBadge({
                 status={tilstand}
                 penskrivStatus={penskrivVirksomhetTilstand}
                 hentTagProps={hentTagPropsForVirksomhetTilstand}
+                hentHjelpetekst={hentHjelpetekstForVirksomhetTilstand}
             />
         )
     );
@@ -71,3 +72,21 @@ function hentTagPropsForVirksomhetTilstand(
 
     return { variant: "strong", "data-color": "neutral" };
 }
+
+const hentHjelpetekstForVirksomhetTilstand = (
+    tilstand: VirksomhetIATilstand,
+): string | undefined => {
+    switch (tilstand) {
+        case "VirksomhetErAvregistrertIBrreg":
+            return "Virksomheten er slettet i Brønnøysundregistrene.";
+        case "VirksomhetKlarTilVurdering":
+        case "VirksomhetVurderes":
+        case "VirksomhetErVurdert":
+        case "VirksomhetHarAktiveSamarbeid":
+        case "AlleSamarbeidIVirksomhetErAvsluttet":
+            break;
+        default:
+            exhaustive(tilstand);
+    }
+    return undefined;
+};

--- a/client/src/domenetyper/domenetyper.ts
+++ b/client/src/domenetyper/domenetyper.ts
@@ -160,6 +160,7 @@ const VIRKSOMHET_TILSTANDER = [
     "VirksomhetErVurdert",
     "VirksomhetHarAktiveSamarbeid",
     "AlleSamarbeidIVirksomhetErAvsluttet",
+    "VirksomhetErAvregistrertIBrreg",
 ] as const;
 export const VirksomhetIATilstandEnum = z.enum(VIRKSOMHET_TILSTANDER);
 


### PR DESCRIPTION
Pga logikk i backend som sørger for å avslutte sak og avbryte samarbeid, vil ikke knappen for å opprette nye samarbeid dukke opp for virksomheter som er slettet. 

<img width="1186" height="886" alt="image" src="https://github.com/user-attachments/assets/62c092e8-400a-43fd-a559-0465c9026a25" />
<img width="1115" height="569" alt="image" src="https://github.com/user-attachments/assets/1b40ab78-a61e-450d-9bd2-9894daca62ca" />
<img width="800" height="324" alt="image" src="https://github.com/user-attachments/assets/a07526aa-8565-49aa-9bc3-5502e264be0a" />
