### PR TITLE
Legg til exhaustive-sjekker på switch statements

### DIFF
--- a/client/src/Pages/Prioritering/Filter/filtervisning-reducer.ts
+++ b/client/src/Pages/Prioritering/Filter/filtervisning-reducer.ts
@@ -16,6 +16,7 @@ import {
     Sorteringsverdi,
     ValgtSnittFilter,
 } from "../../../domenetyper/filterverdier";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 const næringsgruppeKoderTilNæringsgrupper = (
     næringsgruppeKoder: string[],
@@ -597,8 +598,8 @@ const reducer = (state: FiltervisningState, action: Action) => {
         case "TILBAKESTILL":
             return { ...state, ...initialFiltervisningState };
         default: {
-            const _exaustiveCheck: never = action;
-            return _exaustiveCheck;
+            exhaustive(action);
+            return action;
         }
     }
 };

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/BekreftSisteSamarbeidModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/BekreftSisteSamarbeidModal.tsx
@@ -24,6 +24,7 @@ import { SamarbeidStatusBadge } from "../../../components/Badge/SamarbeidStatusB
 import { isoDato } from "../../../util/dato";
 import styles from "./bekreftSisteSamarbeidModal.module.scss";
 import { useHentPlan } from "../../../api/lydia-api/plan";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 export default function BekreftSisteSamarbeidModal({
     ref,
@@ -188,7 +189,10 @@ function getTittel(nyStatus: IASamarbeidStatusType) {
             return "Fullfør samarbeidet";
         case "SLETTET":
             return "Slett samarbeidet";
+        case "AKTIV":
+            return "";
         default:
+            exhaustive(nyStatus);
             return "";
     }
 }
@@ -201,7 +205,10 @@ function getStatusPresens(nyStatus: IASamarbeidStatusType) {
             return "fullfører";
         case "SLETTET":
             return "sletter";
+        case "AKTIV":
+            return "";
         default:
+            exhaustive(nyStatus);
             return "";
     }
 }

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/SlettSamarbeidModalBegrunnelser.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/SlettSamarbeidModalBegrunnelser.tsx
@@ -7,6 +7,7 @@ import { BodyShort, Heading, List, LocalAlert } from "@navikt/ds-react";
 import { useHentSalesforceSamarbeidLenke } from "../../../api/lydia-api/virksomhet";
 import { EksternLenke } from "../../../components/EksternLenke";
 import { useSamarbeidContext } from "../Samarbeid/SamarbeidContext";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 export default function SlettSamarbeidModalBegrunnelser({
     kanGjennomføreResultat,
@@ -99,9 +100,16 @@ function BegrunnelsesInnhold({
             );
         case "FINNES_EVALUERING":
             return <Heading size={"xsmall"}>Det finnes en evaluering</Heading>;
+        case "INGEN_EVALUERING":
+        case "INGEN_PLAN":
+        case "AKTIV_EVALUERING":
+        case "AKTIV_BEHOVSVURDERING":
+        case "SAK_I_FEIL_STATUS":
+            break;
         default:
-            return null;
+            exhaustive(begrunnelse);
     }
+    return null;
 }
 
 function Salesforcelenke({ samarbeidId }: { samarbeidId?: number }) {

--- a/client/src/Pages/Virksomhet/Kartlegging/PubliserSpørreundersøkelse.tsx
+++ b/client/src/Pages/Virksomhet/Kartlegging/PubliserSpørreundersøkelse.tsx
@@ -10,6 +10,7 @@ import {
 import { PubliseringModal } from "./PubliseringModal";
 import styles from "./publiserSpørreundersøkelse.module.scss";
 import { lokalDato } from "../../../util/dato";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 interface Props {
     spørreundersøkelse: Spørreundersøkelse;
@@ -117,9 +118,12 @@ export const PubliserSpørreundersøkelse = ({
             } else {
                 return null;
             }
+        case undefined:
+            break;
         default:
-            return null;
+            exhaustive(spørreundersøkelse.publiseringStatus);
     }
+    return null;
 };
 
 export function PubliserDokumentknapp({

--- a/client/src/Pages/Virksomhet/Plan/PubliserSamarbeidsplan.tsx
+++ b/client/src/Pages/Virksomhet/Plan/PubliserSamarbeidsplan.tsx
@@ -13,6 +13,7 @@ import { PubliseringModal } from "./PubliseringModal";
 import { IASak } from "../../../domenetyper/domenetyper";
 import { useHentBrukerinformasjon } from "../../../api/lydia-api/bruker";
 import { useHentTeam } from "../../../api/lydia-api/team";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 interface Props {
     plan: Plan;
@@ -137,9 +138,13 @@ export const PubliserSamarbeidsplan = ({
                     />
                 </>
             );
+        case null:
+        case undefined:
+            break;
         default:
-            return null;
+            exhaustive(plan?.publiseringStatus);
     }
+    return null;
 };
 
 function BrukerMåVæreEierKnapp() {

--- a/client/src/Pages/Virksomhet/Samarbeid/EndreSamarbeidModal/BegrunnelserForIkkeKunne.tsx
+++ b/client/src/Pages/Virksomhet/Samarbeid/EndreSamarbeidModal/BegrunnelserForIkkeKunne.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../../../domenetyper/samarbeidsEndring";
 import React from "react";
 import styles from "./endresamarbeidmodal.module.scss";
+import { exhaustive } from "../../../../util/exhaustive_types";
 
 export default function BegrunnelserForIkkeKunne({
     begrunnelser,
@@ -59,6 +60,12 @@ export function usePrettyType(type: MuligSamarbeidsgandling) {
                     capitalized: "Avbryt",
                     uncapitalized: "avbryt",
                 };
+            default:
+                exhaustive(type);
+                return {
+                    capitalized: "",
+                    uncapitalized: "",
+                };
         }
     }, [type]);
 }
@@ -92,6 +99,7 @@ function usePrettyBegrunnelser(
                 case "INGEN_PLAN":
                     return "Mangler samarbeidsplan";
                 default:
+                    exhaustive(begrunnelse);
                     return begrunnelse;
             }
         });

--- a/client/src/Pages/Virksomhet/Samarbeid/EndreSamarbeidModal/BekreftHandlingModal.tsx
+++ b/client/src/Pages/Virksomhet/Samarbeid/EndreSamarbeidModal/BekreftHandlingModal.tsx
@@ -12,6 +12,7 @@ import BegrunnelserForIkkeKunne, {
     usePrettyType,
 } from "./BegrunnelserForIkkeKunne";
 import styles from "./endresamarbeidmodal.module.scss";
+import { exhaustive } from "../../../../util/exhaustive_types";
 
 export default function BekreftHandlingModal({
     open,
@@ -94,6 +95,9 @@ function BekreftHandlingBrødtekst({ type }: { type: MuligSamarbeidsgandling }) 
                 return "Samarbeid med fullførte behovsvurderinger, evalueringer og aktive planer kan ikke slettes. Aktiviteter i Salesforce må slettes eller flyttes til at annet samarbeid.";
             case "avbrytes":
                 return "Når du avbryter vil alle dokumenter bli arkivert og det vil ikke være mulig å gjøre endringer på samarbeidet.";
+            default:
+                exhaustive(type);
+                return "";
         }
     }, [type]);
 

--- a/client/src/Pages/Virksomhet/Samarbeid/EndreSamarbeidModal/index.tsx
+++ b/client/src/Pages/Virksomhet/Samarbeid/EndreSamarbeidModal/index.tsx
@@ -19,6 +19,7 @@ import {
     useHentHistorikkNyFlyt,
     useHentSpesifikkSakNyFlyt,
 } from "../../../../api/lydia-api/nyFlyt";
+import { exhaustive } from "../../../../util/exhaustive_types";
 
 interface EndreSamarbeidModalProps {
     open: boolean;
@@ -170,5 +171,8 @@ function getHendelseFromType(
             return IASakshendelseTypeEnum.enum.AVBRYT_PROSESS;
         case "slettes":
             return IASakshendelseTypeEnum.enum.SLETT_PROSESS;
+        default:
+            exhaustive(type);
+            return undefined as never;
     }
 }

--- a/client/src/Pages/Virksomhet/Statistikk/Graf/Graf.tsx
+++ b/client/src/Pages/Virksomhet/Statistikk/Graf/Graf.tsx
@@ -17,6 +17,7 @@ import { SymbolSvg } from "./SymbolSvg";
 import { loggGraflinjeEndringer } from "../../../../util/analytics-klient";
 import { HistoriskStatistikk } from "../../../../domenetyper/historiskstatistikk";
 import styles from "./graf.module.scss";
+import { exhaustive } from "../../../../util/exhaustive_types";
 
 const kvartalSomTekst = (årstall: number, kvartal: number) =>
     årstall + ", " + kvartal + ". kvartal";
@@ -109,8 +110,11 @@ export default function Graf({
             case Grafer.SEKTOR:
                 return `: ${historiskStatistikk.sektorstatistikk.beskrivelse}`;
             case Grafer.LAND:
-                return "";
+                break;
+            default:
+                exhaustive(navnTilStatistikk);
         }
+        return "";
     };
 
     const endringIValgteLinjer = (valgteLinjer: string[]) => {

--- a/client/src/Pages/Virksomhet/VirksomhetsVisning.tsx
+++ b/client/src/Pages/Virksomhet/VirksomhetsVisning.tsx
@@ -28,6 +28,7 @@ import {
     useHentSpesifikkSakNyFlyt,
 } from "../../api/lydia-api/nyFlyt";
 import AdministrerSamarbeid from "./AdministrerSamarbeid";
+import { exhaustive } from "../../util/exhaustive_types";
 
 interface Props {
     virksomhet: Virksomhet;
@@ -273,6 +274,7 @@ function getKlassenavnForSamarbeidsstatus(status: IASamarbeidStatusType) {
         case "SLETTET":
             return styles.slettet;
         default:
+            exhaustive(status);
             return "";
     }
 }

--- a/client/src/components/Badge/IAProsessStatusBadge.tsx
+++ b/client/src/components/Badge/IAProsessStatusBadge.tsx
@@ -4,6 +4,7 @@ import {
     IAProsessStatusType,
 } from "../../domenetyper/domenetyper";
 import { GenericProps, GenericStatusBadge } from "./StatusBadge";
+import { exhaustive } from "../../util/exhaustive_types";
 
 export type StatusBadgeProps = Omit<
     GenericProps<IAProsessStatusType>,
@@ -47,6 +48,7 @@ export function penskrivIAStatus(status: IAProsessStatusType) {
         case IAProsessStatusEnum.enum.AVBRUTT:
             return "Avbrutt";
         default:
+            exhaustive(status);
             return status;
     }
 }
@@ -79,7 +81,8 @@ export function hentTagPropsForIAStatus(
             return { variant: "strong", "data-color": "meta-lime" };
         case IAProsessStatusEnum.enum.IKKE_AKTUELL:
             return { variant: "strong", "data-color": "danger" };
+        default:
+            exhaustive(status);
+            return {};
     }
-
-    return {};
 }

--- a/client/src/components/Badge/SpørreundersøkelseStatusBadge.tsx
+++ b/client/src/components/Badge/SpørreundersøkelseStatusBadge.tsx
@@ -5,6 +5,7 @@ import {
 } from "../../domenetyper/domenetyper";
 import { GenericProps, GenericStatusBadge } from "./StatusBadge";
 import { TagProps } from "@navikt/ds-react";
+import { exhaustive } from "../../util/exhaustive_types";
 
 function hentTagPropsForSpørreundersøkelseStatus(
     status: SpørreundersøkelseStatus,
@@ -18,8 +19,10 @@ function hentTagPropsForSpørreundersøkelseStatus(
             return { variant: "moderate", "data-color": "success" };
         case spørreundersøkelseStatusEnum.enum.SLETTET:
             return { variant: "outline", "data-color": "danger" };
+        default:
+            exhaustive(status);
+            return {};
     }
-    return {};
 }
 
 export function penskrivSpørreundersøkelseStatus(
@@ -34,6 +37,9 @@ export function penskrivSpørreundersøkelseStatus(
             return "Fullført";
         case spørreundersøkelseStatusEnum.enum.SLETTET:
             return "Slettet";
+        default:
+            exhaustive(status);
+            return "";
     }
 }
 

--- a/client/src/components/Badge/VirksomhetTilstandStatusBadge.tsx
+++ b/client/src/components/Badge/VirksomhetTilstandStatusBadge.tsx
@@ -4,6 +4,7 @@ import {
 } from "../../domenetyper/domenetyper";
 import { GenericProps, GenericStatusBadge } from "./StatusBadge";
 import { TagProps } from "@navikt/ds-react";
+import { exhaustive } from "../../util/exhaustive_types";
 
 export type StatusBadgeProps = Omit<
     GenericProps<VirksomhetIATilstand>,
@@ -41,6 +42,7 @@ export function penskrivVirksomhetTilstand(tilstand: VirksomhetIATilstand) {
         case VirksomhetIATilstandEnum.enum.AlleSamarbeidIVirksomhetErAvsluttet:
             return "Avsluttet";
         default:
+            exhaustive(tilstand);
             return tilstand;
     }
 }
@@ -56,7 +58,10 @@ function hentTagPropsForVirksomhetTilstand(
         case VirksomhetIATilstandEnum.enum.VirksomhetHarAktiveSamarbeid:
             return { variant: "outline", "data-color": "brand-blue" };
         case VirksomhetIATilstandEnum.enum.AlleSamarbeidIVirksomhetErAvsluttet:
-            return { variant: "strong", "data-color": "neutral" };
+        case VirksomhetIATilstandEnum.enum.VirksomhetKlarTilVurdering:
+            break;
+        default:
+            exhaustive(tilstand);
     }
 
     return { variant: "strong", "data-color": "neutral" };

--- a/client/src/components/Samarbeidsfanemeny.tsx
+++ b/client/src/components/Samarbeidsfanemeny.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { DokumentType } from "../domenetyper/domenetyper";
 import capitalizeFirstLetterLowercaseRest from "../util/formatering/capitalizeFirstLetterLowercaseRest";
 import styles from "./components.module.scss";
+import { exhaustive } from "../util/exhaustive_types";
 
 export default function Samarbeidsfanemeny({
     type,
@@ -40,7 +41,8 @@ export default function Samarbeidsfanemeny({
                                 title="Meny"
                             />
                         )
-                    } />
+                    }
+                />
             </ActionMenu.Trigger>
             <ActionMenu.Content>
                 {type && (
@@ -193,6 +195,9 @@ function Samarbeidsfanelenkeliste({
                     </ActionMenu.Group>
                 </>
             );
+        default:
+            exhaustive(type);
+            return undefined as never;
     }
 }
 

--- a/client/src/components/Spørreundersøkelse/SpørreundersøkelseHeading.tsx
+++ b/client/src/components/Spørreundersøkelse/SpørreundersøkelseHeading.tsx
@@ -2,6 +2,7 @@ import { HStack } from "@navikt/ds-react";
 import { IaSakProsess } from "../../domenetyper/iaSakProsess";
 import { SpørreundersøkelseType } from "../../domenetyper/spørreundersøkelseMedInnhold";
 import Samarbeidsfanemeny from "../Samarbeidsfanemeny";
+import { exhaustive } from "../../util/exhaustive_types";
 
 export const SpørreundersøkelseHeading = ({
     type,
@@ -29,7 +30,10 @@ export function spørreundersøkelseHeading(type?: SpørreundersøkelseType) {
             return "Evaluering";
         case "BEHOVSVURDERING":
             return "Behovsvurdering";
+        case undefined:
+            break;
         default:
-            return null;
+            return exhaustive(type);
     }
+    return null;
 }

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/SpørreundersøkelseRad.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/SpørreundersøkelseRad.tsx
@@ -15,6 +15,7 @@ import { useSpørreundersøkelse } from "../SpørreundersøkelseContext";
 import { useHentIASaksStatus } from "../../../api/lydia-api/sak";
 import { slettKartleggingNyFlyt } from "../../../api/lydia-api/nyFlyt";
 import { useSamarbeidContext } from "../../../Pages/Virksomhet/Samarbeid/SamarbeidContext";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 export default function SpørreundersøkelseRad({
     spørreundersøkelse,
@@ -201,6 +202,9 @@ export default function SpørreundersøkelseRad({
                 </ExpansionCard>
             );
         case spørreundersøkelseStatusEnum.enum.SLETTET:
-            return null;
+            break;
+        default:
+            exhaustive(spørreundersøkelse.status);
     }
+    return null;
 }

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/utils.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/utils.tsx
@@ -1,4 +1,5 @@
 import { SpørreundersøkelseType } from "../../../domenetyper/spørreundersøkelseMedInnhold";
+import { exhaustive } from "../../../util/exhaustive_types";
 
 export function formaterSpørreundersøkelsetype(
     type: SpørreundersøkelseType,
@@ -16,6 +17,10 @@ export function formaterSpørreundersøkelsetype(
                 return "Evaluering";
             }
             return "evaluering";
+
+        default:
+            exhaustive(type);
+            return "";
     }
 }
 

--- a/client/src/components/Spørreundersøkelse/dato.tsx
+++ b/client/src/components/Spørreundersøkelse/dato.tsx
@@ -5,6 +5,7 @@ import {
     lokalDato,
 } from "../../util/dato";
 import { sorterPåDatoSynkende } from "../../util/sortering";
+import { exhaustive } from "../../util/exhaustive_types";
 
 export function sorterPåDato(spørreundersøkelser: Spørreundersøkelse[]) {
     return spørreundersøkelser.sort((a, b) =>
@@ -34,6 +35,9 @@ const hentDatoForStatus = (spørreundersøkelse: Spørreundersøkelse) => {
                 spørreundersøkelse.endretTidspunkt ||
                 spørreundersøkelse.opprettetTidspunkt
             );
+        default:
+            exhaustive(spørreundersøkelse.status);
+            return undefined as never;
     }
 };
 

--- a/client/src/util/exhaustive_types.ts
+++ b/client/src/util/exhaustive_types.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const exhaustive = (_: never) => {};

--- a/client/src/util/formatering/useBøyninger.ts
+++ b/client/src/util/formatering/useBøyninger.ts
@@ -3,6 +3,7 @@ import {
     muligeHandlinger,
     MuligSamarbeidsgandling,
 } from "../../domenetyper/samarbeidsEndring";
+import { exhaustive } from "../exhaustive_types";
 
 export type Bøyinger = {
     infinitiv: string | null;
@@ -33,6 +34,14 @@ export function useBøyningerAvSamarbeidshandling(
                     imperativ: "slett",
                     presensPerfektum: "slettet",
                 };
+            default: {
+                exhaustive(handling);
+                return {
+                    imperativ: null,
+                    infinitiv: null,
+                    presensPerfektum: null,
+                };
+            }
         }
     }, [handling]);
 }


### PR DESCRIPTION
Jeg har prøvd å holde returtyper like som før, men var usikker på noen av tilfellene hvor returtypen kan være undefined, men det ikke kommer frem av signaturen.