### PR TITLE
Ta i bruk endepunkter på nyflyt api path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/updates-uke-26-26'
+    if: github.ref == 'refs/heads/ta-i-bruk-endepunkter-paa-nyflyt-api-path'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0

--- a/client/__tests__/komponenttester/BekreftSisteSamarbeidModal.test.tsx
+++ b/client/__tests__/komponenttester/BekreftSisteSamarbeidModal.test.tsx
@@ -200,6 +200,7 @@ describe("BekreftSisteSamarbeidModal", () => {
         await waitFor(() => {
             expect(mockAvsluttSamarbeid).toHaveBeenCalledWith(
                 "999999999",
+                "123",
                 1,
                 expect.objectContaining({ status: "FULLFØRT" }),
                 expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),

--- a/client/__tests__/komponenttester/BekreftSisteSamarbeidModal.test.tsx
+++ b/client/__tests__/komponenttester/BekreftSisteSamarbeidModal.test.tsx
@@ -39,7 +39,7 @@ const lagSamarbeid = (overrides: Partial<IaSakProsess> = {}): IaSakProsess => ({
 });
 
 const lagIaSak = (overrides: Partial<IASak> = {}): IASak =>
-    (({
+    ({
         saksnummer: "123",
         orgnr: "999999999",
         opprettetTidspunkt: new Date().toISOString(),
@@ -51,8 +51,8 @@ const lagIaSak = (overrides: Partial<IASak> = {}): IASak =>
         status: "VI_BISTÅR",
         gyldigeNesteHendelser: [],
         lukket: false,
-        ...overrides
-    }) as IASak);
+        ...overrides,
+    }) as IASak;
 
 function renderModal(props: {
     nyStatus: "AVBRUTT" | "FULLFØRT" | "SLETTET";
@@ -181,6 +181,7 @@ describe("BekreftSisteSamarbeidModal", () => {
         await waitFor(() => {
             expect(mockSlettSamarbeid).toHaveBeenCalledWith(
                 "999999999",
+                "123",
                 1,
                 expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
             );

--- a/client/__tests__/komponenttester/Pages/MineSaker/TeamModal.test.tsx
+++ b/client/__tests__/komponenttester/Pages/MineSaker/TeamModal.test.tsx
@@ -84,7 +84,10 @@ describe("TeamModal", () => {
         await waitFor(() => {
             expect(nyFlyt.bliEierNyFlyt).toHaveBeenCalledTimes(1);
         });
-        expect(nyFlyt.bliEierNyFlyt).toHaveBeenCalledWith(dummyIaSak.orgnr);
+        expect(nyFlyt.bliEierNyFlyt).toHaveBeenCalledWith(
+            dummyIaSak.orgnr,
+            dummyIaSak.saksnummer,
+        );
     });
 
     it("kaller setOpen(false) ved klikk på 'Ferdig'", () => {

--- a/client/__tests__/komponenttester/Pages/NyFlyt/AvbrytSamarbeidModal.test.tsx
+++ b/client/__tests__/komponenttester/Pages/NyFlyt/AvbrytSamarbeidModal.test.tsx
@@ -106,6 +106,7 @@ describe("AvbrytSamarbeidModal", () => {
         await waitFor(() => {
             expect(avsluttSamarbeidMock).toHaveBeenCalledWith(
                 "123456789",
+                "SAK-001",
                 1,
                 expect.objectContaining({
                     id: 1,
@@ -195,6 +196,7 @@ describe("AvbrytSamarbeidModal", () => {
             await waitFor(() => {
                 expect(avsluttSamarbeidMock).toHaveBeenCalledWith(
                     "123456789",
+                    "SAK-001",
                     1,
                     expect.objectContaining({
                         id: 1,

--- a/client/__tests__/komponenttester/Pages/NyFlyt/FullførSamarbeidModal.test.tsx
+++ b/client/__tests__/komponenttester/Pages/NyFlyt/FullførSamarbeidModal.test.tsx
@@ -188,6 +188,7 @@ describe("FullførSamarbeidModal", () => {
         await waitFor(() => {
             expect(avsluttSamarbeidMock).toHaveBeenCalledWith(
                 "123456789",
+                "SAK-001",
                 1,
                 expect.objectContaining({
                     id: 1,
@@ -240,6 +241,7 @@ describe("FullførSamarbeidModal", () => {
             await waitFor(() => {
                 expect(avsluttSamarbeidMock).toHaveBeenCalledWith(
                     "123456789",
+                    "SAK-001",
                     1,
                     expect.objectContaining({
                         id: 1,

--- a/client/__tests__/komponenttester/Pages/Virksomhet/Kartlegging/Behovsvurdering.test.tsx
+++ b/client/__tests__/komponenttester/Pages/Virksomhet/Kartlegging/Behovsvurdering.test.tsx
@@ -158,6 +158,7 @@ describe("Behovsvurdering", () => {
         await waitFor(() => {
             expect(opprettKartleggingNyFlyt).toHaveBeenCalledWith(
                 dummyIaSak.orgnr,
+                dummyIaSak.saksnummer,
                 gjeldendeSamarbeid.id,
                 "BEHOVSVURDERING",
             );

--- a/client/__tests__/komponenttester/Pages/Virksomhet/SlettSamarbeidModal.test.tsx
+++ b/client/__tests__/komponenttester/Pages/Virksomhet/SlettSamarbeidModal.test.tsx
@@ -145,6 +145,7 @@ describe("SlettSamarbeidModal", () => {
             await waitFor(() => {
                 expect(slettSamarbeidNyFlyt).toHaveBeenCalledWith(
                     iaSak.orgnr,
+                    iaSak.saksnummer,
                     42,
                 );
             });
@@ -268,6 +269,7 @@ describe("SlettSamarbeidModal", () => {
             await waitFor(() => {
                 expect(slettSamarbeidNyFlyt).toHaveBeenCalledWith(
                     iaSak.orgnr,
+                    iaSak.saksnummer,
                     5,
                     expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
                 );
@@ -287,6 +289,7 @@ describe("SlettSamarbeidModal", () => {
             await waitFor(() => {
                 expect(slettSamarbeidNyFlyt).toHaveBeenCalledWith(
                     iaSak.orgnr,
+                    iaSak.saksnummer,
                     10,
                 );
             });

--- a/client/src/Pages/MineSaker/TeamInnhold.tsx
+++ b/client/src/Pages/MineSaker/TeamInnhold.tsx
@@ -59,7 +59,7 @@ export default function TeamInnhold({
     const muterOversikt = useOversiktMutate(iaSak.orgnr);
 
     const gjørTaEierskap = async () => {
-        await bliEierNyFlyt(iaSak.orgnr);
+        await bliEierNyFlyt(iaSak.orgnr, iaSak.saksnummer);
         muterIaSak();
         muterMineSaker();
         muterOversikt();

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/AvbrytSamarbeidModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/AvbrytSamarbeidModal.tsx
@@ -128,7 +128,7 @@ export default function AvbrytSamarbeidModal({
         }
 
         try {
-            if (!valgtSamarbeid?.id || !iaSak?.orgnr) {
+            if (!valgtSamarbeid?.id || !iaSak?.orgnr || !iaSak?.saksnummer) {
                 return;
             }
 
@@ -142,8 +142,9 @@ export default function AvbrytSamarbeidModal({
             };
 
             await avsluttSamarbeidNyFlyt(
-                iaSak?.orgnr || "",
-                valgtSamarbeid?.id,
+                iaSak.orgnr,
+                iaSak.saksnummer,
+                valgtSamarbeid.id,
                 samarbeid,
             );
         } catch {

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/BekreftSisteSamarbeidModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/BekreftSisteSamarbeidModal.tsx
@@ -70,7 +70,7 @@ export default function BekreftSisteSamarbeidModal({
         setSenderRequest(true);
 
         try {
-            if (!valgtSamarbeid?.id || !iaSak?.orgnr) {
+            if (!valgtSamarbeid?.id || !iaSak?.orgnr || !iaSak?.saksnummer) {
                 return;
             }
 
@@ -94,8 +94,9 @@ export default function BekreftSisteSamarbeidModal({
                 };
 
                 await avsluttSamarbeidNyFlyt(
-                    iaSak?.orgnr || "",
-                    valgtSamarbeid?.id,
+                    iaSak.orgnr,
+                    iaSak.saksnummer,
+                    valgtSamarbeid.id,
                     samarbeid,
                     dato,
                 );

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/BekreftSisteSamarbeidModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/BekreftSisteSamarbeidModal.tsx
@@ -79,6 +79,7 @@ export default function BekreftSisteSamarbeidModal({
             if (nyStatus === "SLETTET") {
                 await slettSamarbeidNyFlyt(
                     iaSak.orgnr,
+                    iaSak.saksnummer,
                     valgtSamarbeid.id,
                     dato,
                 );

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/EndreSamarbeidsnavnModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/EndreSamarbeidsnavnModal.tsx
@@ -47,12 +47,12 @@ export default function EndreSamarbeidsnavnModal({
     const endreNavn = async () => {
         if (!iaSak?.orgnr) return;
         try {
-            await endreSamarbeidsNavnNyFlyt(iaSak.orgnr, valgtSamarbeid.id, {
-                id: valgtSamarbeid.id,
-                saksnummer: valgtSamarbeid.saksnummer,
-                navn: navn,
-                status: valgtSamarbeid.status,
-            });
+            await endreSamarbeidsNavnNyFlyt(
+                iaSak.orgnr,
+                iaSak.saksnummer,
+                valgtSamarbeid.id,
+                navn,
+            );
             setLagreNavnVellykket(true);
             ref.current?.close();
         } finally {

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/FullførSamarbeidModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/FullførSamarbeidModal.tsx
@@ -135,7 +135,7 @@ export default function FullførSamarbeidModal({
             return;
         }
         try {
-            if (!valgtSamarbeid?.id || !iaSak?.orgnr) {
+            if (!valgtSamarbeid?.id || !iaSak?.orgnr || !iaSak?.saksnummer) {
                 return;
             }
 
@@ -149,8 +149,9 @@ export default function FullførSamarbeidModal({
             };
 
             await avsluttSamarbeidNyFlyt(
-                iaSak?.orgnr || "",
-                valgtSamarbeid?.id,
+                iaSak.orgnr,
+                iaSak.saksnummer,
+                valgtSamarbeid.id,
                 samarbeid,
             );
         } catch {

--- a/client/src/Pages/Virksomhet/AdministrerSamarbeid/SlettSamarbeidModal.tsx
+++ b/client/src/Pages/Virksomhet/AdministrerSamarbeid/SlettSamarbeidModal.tsx
@@ -62,7 +62,11 @@ export default function SlettSamarbeidModal({
             return;
         } else if (iaSak && valgtSamarbeid) {
             try {
-                await slettSamarbeidNyFlyt(iaSak?.orgnr, valgtSamarbeid?.id);
+                await slettSamarbeidNyFlyt(
+                    iaSak?.orgnr,
+                    iaSak?.saksnummer,
+                    valgtSamarbeid?.id,
+                );
                 ref.current?.close();
             } catch (e) {
                 setError(e instanceof Error ? e.message : String(e));

--- a/client/src/Pages/Virksomhet/Debugside/Delete.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Delete.tsx
@@ -179,7 +179,11 @@ export function SlettSamarbeid({ orgnummer, onSuccess }: DeleteProps) {
     const handleSubmit = async () => {
         setError(null);
         try {
-            const result = await slettSamarbeidNyFlyt(orgnummer, Number(samarbeidId));
+            const result = await slettSamarbeidNyFlyt(
+                orgnummer,
+                iaSak?.saksnummer || "",
+                Number(samarbeidId),
+            );
             setResponse(result);
             onSuccess();
         } catch (e) {

--- a/client/src/Pages/Virksomhet/Debugside/Delete.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Delete.tsx
@@ -64,6 +64,7 @@ export function SlettKartlegging({ orgnummer, onSuccess }: DeleteProps) {
         try {
             const result = await slettKartleggingNyFlyt(
                 orgnummer,
+                iaSak?.saksnummer || "",
                 samarbeidId,
                 spørreundersøkelseId,
             );

--- a/client/src/Pages/Virksomhet/Debugside/Post.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Post.tsx
@@ -97,13 +97,18 @@ export function VurderSak({ orgnummer, onSuccess }: PostProps) {
 }
 
 export function BliEier({ orgnummer, onSuccess }: PostProps) {
+    const { data: iaSak } = useHentSisteSakNyFlyt(orgnummer);
     const [response, setResponse] = useState<object | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     const handleSubmit = async () => {
         setError(null);
         try {
-            const result = await bliEierNyFlyt(orgnummer);
+            if (!iaSak?.saksnummer) {
+                setError("Saksnummer ikke tilgjengelig");
+                return;
+            }
+            const result = await bliEierNyFlyt(orgnummer, iaSak.saksnummer);
             setResponse(result);
             onSuccess();
         } catch (e) {

--- a/client/src/Pages/Virksomhet/Debugside/Post.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Post.tsx
@@ -448,6 +448,7 @@ export function StartKartlegging({ orgnummer, onSuccess }: PostProps) {
         try {
             const result = await startKartleggingNyFlyt(
                 orgnummer,
+                iaSak?.saksnummer || "",
                 samarbeidId,
                 spørreundersøkelseId,
             );

--- a/client/src/Pages/Virksomhet/Debugside/Post.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Post.tsx
@@ -507,6 +507,7 @@ export function FullførKartlegging({ orgnummer, onSuccess }: PostProps) {
         try {
             const result = await fullførKartleggingNyFlyt(
                 orgnummer,
+                iaSak?.saksnummer || "",
                 samarbeidId,
                 spørreundersøkelseId,
             );

--- a/client/src/Pages/Virksomhet/Debugside/Post.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Post.tsx
@@ -681,6 +681,7 @@ export function AvsluttSamarbeid({ orgnummer, onSuccess }: PostProps) {
             };
             const result = await avsluttSamarbeidNyFlyt(
                 orgnummer,
+                iaSak?.saksnummer || "",
                 Number(samarbeidId),
                 samarbeid,
             );

--- a/client/src/Pages/Virksomhet/Debugside/Post.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Post.tsx
@@ -381,6 +381,7 @@ export function OpprettKartlegging({ orgnummer, onSuccess }: PostProps) {
         try {
             const result = await opprettKartleggingNyFlyt(
                 orgnummer,
+                iaSak?.saksnummer || "",
                 samarbeidId,
                 type,
             );

--- a/client/src/Pages/Virksomhet/Debugside/Put.tsx
+++ b/client/src/Pages/Virksomhet/Debugside/Put.tsx
@@ -73,13 +73,9 @@ export function EndreSamarbeidsNavn({ orgnummer, onSuccess }: PutProps) {
         try {
             const result = await endreSamarbeidsNavnNyFlyt(
                 orgnummer,
+                valgtSamarbeid.saksnummer,
                 Number(samarbeidId),
-                {
-                    id: valgtSamarbeid.id,
-                    saksnummer: valgtSamarbeid.saksnummer,
-                    navn: nyttNavn,
-                    status: valgtSamarbeid.status,
-                },
+                nyttNavn,
             );
             setResponse(result);
             onSuccess();

--- a/client/src/Pages/Virksomhet/Kartlegging/Kartleggingsliste/index.tsx
+++ b/client/src/Pages/Virksomhet/Kartlegging/Kartleggingsliste/index.tsx
@@ -81,14 +81,17 @@ function Innhold({
 
     const opprettSpørreundersøkelseOgMuter = (type: SpørreundersøkelseType) => {
         setSistOpprettetType(null);
-        opprettKartleggingNyFlyt(iaSak.orgnr, gjeldendeSamarbeid.id, type).then(
-            ({ id }) => {
-                setSisteOpprettedeId(id);
-                hentSpørreundersøkelserPåNytt();
-                oppdaterSaksStatus();
-                setSistOpprettetType(type);
-            },
-        );
+        opprettKartleggingNyFlyt(
+            iaSak.orgnr,
+            iaSak.saksnummer,
+            gjeldendeSamarbeid.id,
+            type,
+        ).then(({ id }) => {
+            setSisteOpprettedeId(id);
+            hentSpørreundersøkelserPåNytt();
+            oppdaterSaksStatus();
+            setSistOpprettetType(type);
+        });
     };
 
     if (loading || !data) {

--- a/client/src/api/lydia-api/networkRequests.ts
+++ b/client/src/api/lydia-api/networkRequests.ts
@@ -43,7 +43,7 @@ const defaultFetcher = (...args: [url: string, options?: RequestInit]) =>
     });
 
 const fetchNative =
-    (method: "POST" | "DELETE" | "PUT") =>
+    (method: "POST" | "DELETE" | "PUT" | "PATCH") =>
     <T>(url: string, schema: ZodType<T>, body?: unknown): Promise<T> =>
         csrfFetcher()
             .then((csrfToken) =>
@@ -90,16 +90,24 @@ const fetchNative =
                     : Promise.reject(safeparsed.error);
             });
 
+export const patch = <T>(
+    url: string,
+    schema: ZodType<T>,
+    body?: unknown,
+): Promise<T> => fetchNative("PATCH")(url, schema, body);
+
 export const post = <T>(
     url: string,
     schema: ZodType<T>,
     body?: unknown,
 ): Promise<T> => fetchNative("POST")(url, schema, body);
+
 export const put = <T>(
     url: string,
     schema: ZodType<T>,
     body?: unknown,
 ): Promise<T> => fetchNative("PUT")(url, schema, body);
+
 export const httpDelete = <T>(url: string, schema: ZodType<T>): Promise<T> =>
     fetchNative("DELETE")(url, schema);
 

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -47,7 +47,8 @@ export const useHentTilstandForVirksomhetNyFlyt = (orgnummer?: string) => {
 
 export const useHentVirksomhetNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<Virksomhet>(
-        () => (orgnummer ? `${nyFlytBasePath}/virksomhet/${orgnummer}` : null),
+        () =>
+            orgnummer ? `${nyFlytApiBasePath}/virksomhet/${orgnummer}` : null,
         virksomhetsSchema,
         {
             revalidateOnFocus: true,

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -118,17 +118,6 @@ export const bliEierNyFlyt = (orgnummer: string): Promise<IASak> => {
     return post(`${nyFlytBasePath}/${orgnummer}/bli-eier`, iaSakSchema);
 };
 
-export const opprettSamarbeidNyFlyt = (
-    orgnummer: string,
-    nyttSamarbeid: IaSakProsess,
-): Promise<IaSakProsess> => {
-    return post(
-        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${nyttSamarbeid.saksnummer}/samarbeid`,
-        iaSakProsessSchema,
-        nyttSamarbeid,
-    );
-};
-
 // Samarbeidsperiode
 export const useHentSisteSakNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<IASak>(
@@ -160,14 +149,26 @@ export const useHentSpesifikkSakNyFlyt = (
 };
 
 // Samarbeid
+export const opprettSamarbeidNyFlyt = (
+    orgnummer: string,
+    nyttSamarbeid: IaSakProsess,
+): Promise<IaSakProsess> => {
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${nyttSamarbeid.saksnummer}/samarbeid`,
+        iaSakProsessSchema,
+        nyttSamarbeid,
+    );
+};
+
 export const slettSamarbeidNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: number,
     dato?: string,
 ): Promise<IaSakProsess> => {
     const datoParam = dato ? `?dato=${dato}` : "";
     return httpDelete(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/slett-samarbeid${datoParam}`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}${datoParam}`,
         iaSakProsessSchema,
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -60,7 +60,7 @@ export const useHentHistorikkNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<Sakshistorikk[]>(
         () =>
             orgnummer
-                ? `${nyFlytBasePath}/virksomhet/${orgnummer}/historikk`
+                ? `${nyFlytApiBasePath}/virksomhet/${orgnummer}/historikk`
                 : null,
         sakshistorikkSchema.array(),
         {

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -123,7 +123,7 @@ export const opprettSamarbeidNyFlyt = (
     nyttSamarbeid: IaSakProsess,
 ): Promise<IaSakProsess> => {
     return post(
-        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/opprett-samarbeid`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${nyttSamarbeid.saksnummer}/samarbeid`,
         iaSakProsessSchema,
         nyttSamarbeid,
     );

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -36,6 +36,7 @@ import { nyFlytApiBasePath, nyFlytBasePath } from "./paths";
 import { Virksomhet, virksomhetsSchema } from "../../domenetyper/virksomhet";
 import { isoDato } from "../../util/dato";
 
+// Virksomhet
 export const useHentTilstandForVirksomhetNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<VirksomhetTilstandDto>(
         orgnummer
@@ -56,6 +57,50 @@ export const useHentVirksomhetNyFlyt = (orgnummer?: string) => {
     );
 };
 
+// rename: vurder sak --> vurder virksomhet
+export const vurderSakNyFlyt = (
+    orgnummer: string,
+    årsak: ValgtÅrsakNyFlytDto,
+): Promise<IASak> => {
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/vurder`,
+        iaSakSchema,
+        årsak,
+    );
+};
+
+export const angreVurderingNyFlyt = (orgnummer: string): Promise<IASak> => {
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/angre-vurdering`,
+        iaSakSchema,
+    );
+};
+
+export const avsluttVurderingNyFlyt = (
+    orgnummer: string,
+    årsak: ValgtÅrsakNyFlytDto,
+): Promise<IASak> => {
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/avslutt-vurdering`,
+        iaSakSchema,
+        årsak,
+    );
+};
+
+export const endrePlanlagtDatoNyFlyt = (
+    orgnummer: string,
+    body: VirksomhetTilstandAutomatiskOppdateringDto,
+): Promise<VirksomhetTilstandAutomatiskOppdateringDto> => {
+    return put(
+        `${nyFlytBasePath}/virksomhet/${orgnummer}/endre-planlagt-dato`,
+        virksomhetTilstandAutomatiskOppdateringSchema,
+        {
+            ...body,
+            planlagtDato: isoDato(body.planlagtDato),
+        },
+    );
+};
+
 export const useHentHistorikkNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<Sakshistorikk[]>(
         () =>
@@ -69,6 +114,22 @@ export const useHentHistorikkNyFlyt = (orgnummer?: string) => {
     );
 };
 
+export const bliEierNyFlyt = (orgnummer: string): Promise<IASak> => {
+    return post(`${nyFlytBasePath}/${orgnummer}/bli-eier`, iaSakSchema);
+};
+
+export const opprettSamarbeidNyFlyt = (
+    orgnummer: string,
+    nyttSamarbeid: IaSakProsess,
+): Promise<IaSakProsess> => {
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/opprett-samarbeid`,
+        iaSakProsessSchema,
+        nyttSamarbeid,
+    );
+};
+
+// Samarbeidsperiode
 export const useHentSisteSakNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<IASak>(
         () =>
@@ -98,50 +159,46 @@ export const useHentSpesifikkSakNyFlyt = (
     );
 };
 
-export const vurderSakNyFlyt = (
+// Samarbeid
+export const slettSamarbeidNyFlyt = (
     orgnummer: string,
-    årsak: ValgtÅrsakNyFlytDto,
-): Promise<IASak> => {
-    return post(
-        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/vurder`,
-        iaSakSchema,
-        årsak,
-    );
-};
-
-export const bliEierNyFlyt = (orgnummer: string): Promise<IASak> => {
-    return post(`${nyFlytBasePath}/${orgnummer}/bli-eier`, iaSakSchema);
-};
-
-export const angreVurderingNyFlyt = (orgnummer: string): Promise<IASak> => {
-    return post(
-        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/angre-vurdering`,
-        iaSakSchema,
-    );
-};
-
-export const avsluttVurderingNyFlyt = (
-    orgnummer: string,
-    årsak: ValgtÅrsakNyFlytDto,
-): Promise<IASak> => {
-    return post(
-        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/avslutt-vurdering`,
-        iaSakSchema,
-        årsak,
-    );
-};
-
-export const opprettSamarbeidNyFlyt = (
-    orgnummer: string,
-    nyttSamarbeid: IaSakProsess,
+    samarbeidId: number,
+    dato?: string,
 ): Promise<IaSakProsess> => {
-    return post(
-        `${nyFlytBasePath}/${orgnummer}/opprett-samarbeid`,
+    const datoParam = dato ? `?dato=${dato}` : "";
+    return httpDelete(
+        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/slett-samarbeid${datoParam}`,
         iaSakProsessSchema,
-        nyttSamarbeid,
     );
 };
 
+export const avsluttSamarbeidNyFlyt = (
+    orgnummer: string,
+    samarbeidId: number,
+    samarbeid: SamarbeidRequest,
+    dato?: string,
+): Promise<IaSakProsess> => {
+    const datoParam = dato ? `?dato=${dato}` : "";
+    return post(
+        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/avslutt-samarbeid${datoParam}`,
+        iaSakProsessSchema,
+        samarbeid,
+    );
+};
+
+export const endreSamarbeidsNavnNyFlyt = (
+    orgnummer: string,
+    samarbeidId: number,
+    samarbeid: { id: number; saksnummer: string; navn: string; status: string },
+): Promise<IaSakProsess> => {
+    return put(
+        `${nyFlytBasePath}/virksomhet/${orgnummer}/samarbeid/${samarbeidId}/oppdater`,
+        iaSakProsessSchema,
+        samarbeid,
+    );
+};
+
+// Kartlegging
 export const opprettKartleggingNyFlyt = (
     orgnummer: string,
     samarbeidId: string | number,
@@ -186,6 +243,7 @@ export const slettKartleggingNyFlyt = (
     );
 };
 
+// Samarbeidsplan
 export const opprettSamarbeidsplanNyFlyt = (
     orgnummer: string,
     saksnummer: string,
@@ -253,57 +311,5 @@ export const slettSamarbeidsplanNyFlyt = (
     return httpDelete(
         `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}/plan/${planId}`,
         PlanSchema,
-    );
-};
-
-export const slettSamarbeidNyFlyt = (
-    orgnummer: string,
-    samarbeidId: number,
-    dato?: string,
-): Promise<IaSakProsess> => {
-    const datoParam = dato ? `?dato=${dato}` : "";
-    return httpDelete(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/slett-samarbeid${datoParam}`,
-        iaSakProsessSchema,
-    );
-};
-
-export const avsluttSamarbeidNyFlyt = (
-    orgnummer: string,
-    samarbeidId: number,
-    samarbeid: SamarbeidRequest,
-    dato?: string,
-): Promise<IaSakProsess> => {
-    const datoParam = dato ? `?dato=${dato}` : "";
-    return post(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/avslutt-samarbeid${datoParam}`,
-        iaSakProsessSchema,
-        samarbeid,
-    );
-};
-
-export const endreSamarbeidsNavnNyFlyt = (
-    orgnummer: string,
-    samarbeidId: number,
-    samarbeid: { id: number; saksnummer: string; navn: string; status: string },
-): Promise<IaSakProsess> => {
-    return put(
-        `${nyFlytBasePath}/virksomhet/${orgnummer}/samarbeid/${samarbeidId}/oppdater`,
-        iaSakProsessSchema,
-        samarbeid,
-    );
-};
-
-export const endrePlanlagtDatoNyFlyt = (
-    orgnummer: string,
-    body: VirksomhetTilstandAutomatiskOppdateringDto,
-): Promise<VirksomhetTilstandAutomatiskOppdateringDto> => {
-    return put(
-        `${nyFlytBasePath}/virksomhet/${orgnummer}/endre-planlagt-dato`,
-        virksomhetTilstandAutomatiskOppdateringSchema,
-        {
-            ...body,
-            planlagtDato: isoDato(body.planlagtDato),
-        },
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -114,7 +114,10 @@ export const bliEierNyFlyt = (orgnummer: string): Promise<IASak> => {
 };
 
 export const angreVurderingNyFlyt = (orgnummer: string): Promise<IASak> => {
-    return post(`${nyFlytBasePath}/${orgnummer}/angre-vurdering`, iaSakSchema);
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/angre-vurdering`,
+        iaSakSchema,
+    );
 };
 
 export const avsluttVurderingNyFlyt = (

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -234,11 +234,12 @@ export const startKartleggingNyFlyt = (
 
 export const fullførKartleggingNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: string | number,
     spørreundersøkelseId: string,
 ): Promise<Spørreundersøkelse> => {
     return post(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/fullfor-kartlegging/${spørreundersøkelseId}`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}/kartlegging/${spørreundersøkelseId}/fullfor`,
         spørreundersøkelseSchema,
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -38,7 +38,9 @@ import { isoDato } from "../../util/dato";
 
 export const useHentTilstandForVirksomhetNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<VirksomhetTilstandDto>(
-        orgnummer ? `${nyFlytBasePath}/${orgnummer}/tilstand` : null,
+        orgnummer
+            ? `${nyFlytApiBasePath}/virksomhet/${orgnummer}/tilstand`
+            : null,
         virksomhetTilstandDtoSchema,
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -31,7 +31,13 @@ import {
     spørreundersøkelseSchema,
 } from "../../domenetyper/spørreundersøkelse";
 import { SpørreundersøkelseType } from "../../domenetyper/spørreundersøkelseMedInnhold";
-import { httpDelete, post, put, useSwrTemplate } from "./networkRequests";
+import {
+    httpDelete,
+    patch,
+    post,
+    put,
+    useSwrTemplate,
+} from "./networkRequests";
 import { nyFlytApiBasePath, nyFlytBasePath } from "./paths";
 import { Virksomhet, virksomhetsSchema } from "../../domenetyper/virksomhet";
 import { isoDato } from "../../util/dato";
@@ -189,13 +195,14 @@ export const avsluttSamarbeidNyFlyt = (
 
 export const endreSamarbeidsNavnNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: number,
-    samarbeid: { id: number; saksnummer: string; navn: string; status: string },
+    nyttNavn: string,
 ): Promise<IaSakProsess> => {
-    return put(
-        `${nyFlytBasePath}/virksomhet/${orgnummer}/samarbeid/${samarbeidId}/oppdater`,
+    return patch(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}`,
         iaSakProsessSchema,
-        samarbeid,
+        { typeEndring: "navn", verdi: nyttNavn },
     );
 };
 

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -209,11 +209,12 @@ export const endreSamarbeidsNavnNyFlyt = (
 // Kartlegging
 export const opprettKartleggingNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: string | number,
     type: SpørreundersøkelseType,
 ): Promise<Spørreundersøkelse> => {
     return post(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/opprett-kartlegging/${type}`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}/kartlegging/${type}`,
         spørreundersøkelseSchema,
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -222,11 +222,12 @@ export const opprettKartleggingNyFlyt = (
 
 export const startKartleggingNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: string | number,
     spørreundersøkelseId: string,
 ): Promise<Spørreundersøkelse> => {
     return post(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/start-kartlegging/${spørreundersøkelseId}`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}/kartlegging/${spørreundersøkelseId}/start`,
         spørreundersøkelseSchema,
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -38,7 +38,7 @@ import {
     put,
     useSwrTemplate,
 } from "./networkRequests";
-import { nyFlytApiBasePath, nyFlytBasePath } from "./paths";
+import { nyFlytApiBasePath } from "./paths";
 import { Virksomhet, virksomhetsSchema } from "../../domenetyper/virksomhet";
 import { isoDato } from "../../util/dato";
 
@@ -98,7 +98,7 @@ export const endrePlanlagtDatoNyFlyt = (
     body: VirksomhetTilstandAutomatiskOppdateringDto,
 ): Promise<VirksomhetTilstandAutomatiskOppdateringDto> => {
     return put(
-        `${nyFlytBasePath}/virksomhet/${orgnummer}/endre-planlagt-dato`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/endre-planlagt-dato`,
         virksomhetTilstandAutomatiskOppdateringSchema,
         {
             ...body,

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -102,7 +102,11 @@ export const vurderSakNyFlyt = (
     orgnummer: string,
     årsak: ValgtÅrsakNyFlytDto,
 ): Promise<IASak> => {
-    return post(`${nyFlytBasePath}/${orgnummer}/vurder`, iaSakSchema, årsak);
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/vurder`,
+        iaSakSchema,
+        årsak,
+    );
 };
 
 export const bliEierNyFlyt = (orgnummer: string): Promise<IASak> => {

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -120,8 +120,14 @@ export const useHentHistorikkNyFlyt = (orgnummer?: string) => {
     );
 };
 
-export const bliEierNyFlyt = (orgnummer: string): Promise<IASak> => {
-    return post(`${nyFlytBasePath}/${orgnummer}/bli-eier`, iaSakSchema);
+export const bliEierNyFlyt = (
+    orgnummer: string,
+    saksnummer: string,
+): Promise<IASak> => {
+    return post(
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/bli-eier`,
+        iaSakSchema,
+    );
 };
 
 // Samarbeidsperiode

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -181,13 +181,14 @@ export const slettSamarbeidNyFlyt = (
 
 export const avsluttSamarbeidNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: number,
     samarbeid: SamarbeidRequest,
     dato?: string,
 ): Promise<IaSakProsess> => {
     const datoParam = dato ? `?dato=${dato}` : "";
     return post(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/avslutt-samarbeid${datoParam}`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}${datoParam}`,
         iaSakProsessSchema,
         samarbeid,
     );

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -246,11 +246,12 @@ export const fullførKartleggingNyFlyt = (
 
 export const slettKartleggingNyFlyt = (
     orgnummer: string,
+    saksnummer: string,
     samarbeidId: string | number,
     spørreundersøkelseId: string,
 ): Promise<Spørreundersøkelse> => {
     return httpDelete(
-        `${nyFlytBasePath}/${orgnummer}/${samarbeidId}/slett-kartlegging/${spørreundersøkelseId}`,
+        `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/${samarbeidId}/kartlegging/${spørreundersøkelseId}`,
         spørreundersøkelseSchema,
     );
 };

--- a/client/src/api/lydia-api/nyFlyt.ts
+++ b/client/src/api/lydia-api/nyFlyt.ts
@@ -73,7 +73,7 @@ export const useHentSisteSakNyFlyt = (orgnummer?: string) => {
     return useSwrTemplate<IASak>(
         () =>
             orgnummer
-                ? `${nyFlytBasePath}/virksomhet/${orgnummer}/samarbeidsperiode`
+                ? `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode`
                 : null,
         iaSakSchema,
         {
@@ -89,7 +89,7 @@ export const useHentSpesifikkSakNyFlyt = (
     return useSwrTemplate<IASak>(
         () =>
             orgnummer && saksnummer
-                ? `${nyFlytBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}`
+                ? `${nyFlytApiBasePath}/virksomhet/${orgnummer}/samarbeidsperiode/${saksnummer}`
                 : null,
         iaSakSchema,
         {

--- a/client/src/api/lydia-api/paths.ts
+++ b/client/src/api/lydia-api/paths.ts
@@ -26,7 +26,6 @@ export const planPath = `${iaSakPath}/plan`;
 export const dokumentPath = `${iaSakPath}/dokument`;
 
 // Ny flyt
-export const nyFlytBasePath = `${basePath}/iasak/nyflyt`;
 export const nyFlytApiBasePath = `/proxy/api/v1`;
 
 export const getSykefraværsstatistikkUrl = (søkeverdier: FiltervisningState) =>

--- a/client/src/api/lydia-api/paths.ts
+++ b/client/src/api/lydia-api/paths.ts
@@ -11,7 +11,6 @@ export const iaSakPath = `${basePath}/iasak/radgiver`;
 export const mineSakerPath = `${basePath}/iasak/minesaker`;
 export const iaSakTeamPath = `${basePath}/iasak/team`;
 export const iaSakPostNyHendelsePath = `${iaSakPath}/hendelse`;
-export const iaSakHistorikkPath = `${iaSakPath}/historikk`;
 export const virksomhetAutocompletePath = `${virksomhetsPath}/finn`;
 export const siste4kvartalerPath = "siste4kvartaler";
 export const sistekvartalPath = "sistetilgjengeligekvartal";

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/OpprettetRad.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/OpprettetRad.tsx
@@ -69,6 +69,7 @@ export default function OpprettetRad({
         setSletterSpørreundersøkelse(true);
         slettKartleggingNyFlyt(
             iaSak.orgnr,
+            iaSak.saksnummer,
             samarbeidsId,
             spørreundersøkelse.id,
         ).then(() => {

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/OpprettetRad.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/OpprettetRad.tsx
@@ -56,6 +56,7 @@ export default function OpprettetRad({
     const startSpørreundersøkelsen = () => {
         startKartleggingNyFlyt(
             iaSak.orgnr,
+            iaSak.saksnummer,
             samarbeidsId,
             spørreundersøkelse.id,
         ).then(() => {

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/PåbegyntRad.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/PåbegyntRad.tsx
@@ -69,6 +69,7 @@ export default function PåbegyntRad({
         setSletterSpørreundersøkelse(true);
         slettKartleggingNyFlyt(
             iaSak.orgnr,
+            iaSak.saksnummer,
             samarbeidsId,
             spørreundersøkelse.id,
         ).then(() => {

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/PåbegyntRad.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/PåbegyntRad.tsx
@@ -56,6 +56,7 @@ export default function PåbegyntRad({
     const fullførSpørreundersøkelse = () => {
         fullførKartleggingNyFlyt(
             iaSak.orgnr,
+            iaSak.saksnummer,
             samarbeidsId,
             spørreundersøkelse.id,
         ).then(() => {

--- a/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/SpørreundersøkelseRad.tsx
+++ b/client/src/components/Spørreundersøkelse/Spørreundersøkelseliste/SpørreundersøkelseRad.tsx
@@ -52,6 +52,7 @@ export default function SpørreundersøkelseRad({
         setSletterSpørreundersøkelse(true);
         slettKartleggingNyFlyt(
             iaSak.orgnr,
+            iaSak.saksnummer,
             samarbeidsId,
             spørreundersøkelse.id,
         ).then(() => {


### PR DESCRIPTION
Refactor: flytter og forbedrer noen 'ny flyt' endepunkter.

Ønsket forbedringer:
 - mer RESTfull api (ordentlig path til ressurs, bruk av riktig Http verb)
 - bli kvitt 'ny flyt' i URL
 - bruk av '/proxy/api/v1' root URL

Gjelder følgende endepunkter, per område/ressurs

**Virksomhet**
GET `/api/v1/virksomhet/{orgnummer}` (hent virksomhet)
GET `/api/v1/virksomhet/{orgnummer}/historikk` (hent historikk)
GET `/api/v1/virksomhet/{orgnummer}/tilstand` (hent tilstand til en virksomhet)
PUT `/api/v1/virksomhet/{orgnummer}/endre-planlagt-dato` (endre planlagt dato til neste tilstand)
POST `/api/v1/virksomhet/{orgnummer}/vurder` (vurder virksomhet)
POST `/api/v1/virksomhet/{orgnummer}/angre-vurdering` (angre vurdering)

**Samarbeidsperiode**
GET `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode` (hent aktiv samarbeidsperiode - tidl. IASak )
GET `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}` (hent samarbeidsperiode - tidl. IASak )
POST `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/bli-eier` (bli eier)

**Samarbeid**
POST `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid` (opprett samarbeid)
PATCH `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}` (oppdater navn på samarbeid)
POST `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/{saksnummer}/samarbeid/{samarbeidId}` (avslutt samarbeid)
DELETE `/api/v1/virksomhet/{orgnummer}/samarbeidsperiode/${saksnummer}/samarbeid/{samarbeidId}` (slett samarbeid)
